### PR TITLE
smarter easing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ Keyframed is a time series data type that allows users to store and retrieve dat
         
 setup(
     name='keyframed',
-    version='0.1.2',
+    version='0.1.3',
     author='David Marx',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -198,18 +198,48 @@ class EasingFunction:
 
 class EaseIn(EasingFunction):
     def get_ease_start_t(self):
-        return 0
+        if not self.curve:
+            return 0
+        #return 0
+        k_prev = 0
+        for k in self.curve.keyframes:
+            if self.curve[k] != 0:
+                return k_prev
+            k_prev = k
     def get_ease_end_t(self):
-        return self.curve.keyframes[1]
+        #return self.curve.keyframes[1]
+        for k in self.curve.keyframes:
+            if self.curve[k] != 0:
+                return k
     def use_easing(self, k):
         return k < self.end_t
 
 
 class EaseOut(EasingFunction):
     def get_ease_start_t(self):
-        return self.curve.keyframes[-2]
+        #return self.curve.keyframes[-2]
+        k_prev = -1
+        for k in self.curve.keyframes[::-1]:
+            if k_prev < 0:
+                k_prev = k
+                continue
+            if self.curve[k] != self.curve[k_prev]:
+                return k
+            k_prev = k
+        else:
+            return self.curve.keyframes[-2]
     def get_ease_end_t(self):
-        return self.curve.keyframes[-1]
+        #return self.curve.keyframes[-1]
+        k_prev = -1
+        for k in self.curve.keyframes[::-1]:
+            if k_prev < 0:
+                k_prev = k
+                continue
+            if self.curve[k] != self.curve[k_prev]:
+                return k_prev
+            k_prev = k
+        else:
+            return self.curve.keyframes[-1]
     def use_easing(self, k):
         return k < self.end_t
 


### PR DESCRIPTION
as implemented, easing wasn't supporting cases like `["portrait of queen elizabeth at 16 years old", {20:0, 40:1, 70:0}]` where the easing function doesn't actually start at k=0. modified `get_ease_start_t` and `get_ease_end_t` to figure out where easing should start and end based on the keyframe neighborhood.

* ease out iterates keyframes in reverse until it finds a change in the returned value and uses that as the start of the ease out
* ease in assumes it's entering the curve from 0 and ends the ease in at the keyframe which first returns a non-zero value

the ease out methodology is almost certainly preferable. i implemented ease in first, and i'm gonna leave em both as they are for now just for experimentation purposes. see what happens and what i like or don't about the different approaches.