### PR TITLE
Remove Prompt class: out of scope

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ Keyframed is a time series data type that allows users to store and retrieve dat
         
 setup(
     name='keyframed',
-    version='0.1.9',
+    version='0.2.0',
     author='David Marx',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/src/keyframed/__init__.py
+++ b/src/keyframed/__init__.py
@@ -1,3 +1,3 @@
-from .curve import Keyframe, Curve, PromptState, Prompt, ParameterGroup, register_interpolation_method
+from .curve import Keyframe, Curve, ParameterGroup, register_interpolation_method
 
-__all__ = ['Keyframe','Curve','PromptState','Prompt','ParameterGroup', 'register_interpolation_method']
+__all__ = ['Keyframe','Curve','ParameterGroup', 'register_interpolation_method']

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -428,15 +428,13 @@ class Curve:
 # i'd kind of like this to inherit from dict.
 class ParameterGroup:
     """
-    The ParameterGroup class represents a set of parameters that can be applied to a prompt.
-    It is initialized with a dictionary of parameters, where the keys are the names of the parameters and the values are either Curve objects or Prompt objects.
-    It also has an optional weight parameter, which is a Curve or a Number that is used to modulate the values of the parameters.
-    The class provides a magic method for getting the current parameter values at a given key, and also provides magic methods for addition and multiplication,
-    allowing for easy modification of the weight parameter. It also has a copy method for creating a deep copy of itself.
+    The ParameterGroup class wraps a collection of named parameters to facilitate manipulating them as a unit.
+    Indexing into a ParameterGroup with a frame index returns a dict giving the values of the parameters at that time.
+    The returned values are scaled by a Curve attached to the ParameterGroup `weight` attribute which defaults to a constant value of 1.
     """
     def __init__(
         self,
-        parameters:Dict[str, Curve]=None,
+        parameters:Dict[str, Curve],
         weight:Optional[Union[Curve,Number]]=1
     ):
         if not isinstance(weight, Curve):
@@ -444,7 +442,7 @@ class ParameterGroup:
         self.weight = weight
         self.parameters={}
         for name, v in parameters.items():
-            if isinstance(v, int) or isinstance(v, float):
+            if isinstance(v, Number):
                 v = Curve(v)
             self.parameters[name] = v
 

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -120,25 +120,25 @@ class Keyframe:
             raise TypeError
         return other
 
-    def __add__(self, other):
+    def __add__(self, other) -> Number:
         return self.value + self._to_value(other)
-    def __radd__(self,other):
+    def __radd__(self,other) -> Number:
         return self+other
-    def __le__(self, other):
+    def __le__(self, other) -> bool:
         return self.value <= self._to_value(other)
-    def __ge__(self, other):
+    def __ge__(self, other) -> bool:
         return self.value >= self._to_value(other)
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         return self.value < self._to_value(other)
-    def __gt__(self, other):
+    def __gt__(self, other) -> bool:
         return self.value > self._to_value(other)
-    def __mul__(self, other):
+    def __mul__(self, other) -> Number:
         return self.value * self._to_value(other)
-    def __rmul__(self, other):
+    def __rmul__(self, other) -> Number:
         return self*other
     def __eq__(self, other) -> bool:
         return self.value == other
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Keyframe(t={self.t}, value={self.value}, interpolation_method='{self.interpolation_method}')"
 
 
@@ -151,22 +151,22 @@ class EasingFunction:
         self._start_t=start_t
         self._end_t=end_t
     @property
-    def start_t(self):
+    def start_t(self) -> Number:
         start_t = self._start_t
         if start_t is None:
             start_t = self.get_ease_start_t()
         return start_t
     @property
-    def end_t(self):
+    def end_t(self) -> Number:
         end_t = self._end_t
         if end_t is None:
             end_t = self.get_ease_end_t()
         return end_t
-    def get_ease_start_t(self):
+    def get_ease_start_t(self) -> Number:
         return 0
-    def get_ease_end_t(self):
+    def get_ease_end_t(self) -> Number:
         return 0
-    def use_easing(self, k):
+    def use_easing(self, k) -> bool:
         if self.f is None:
             return False
         return self.start_t < k < self.end_t 
@@ -177,7 +177,7 @@ class EasingFunction:
 #     some stuff in EaseOut maybe?
 
 class EaseIn(EasingFunction):
-    def get_ease_start_t(self):
+    def get_ease_start_t(self) -> Number:
         if not self.curve:
             return 0
         k_prev = 0
@@ -185,11 +185,11 @@ class EaseIn(EasingFunction):
             if self.curve[k] != 0:
                 return k_prev
             k_prev = k
-    def get_ease_end_t(self):
+    def get_ease_end_t(self) -> Number:
         for k in self.curve.keyframes:
             if self.curve[k] != 0:
                 return k
-    def __call__(self,k):
+    def __call__(self,k:Number) -> Number:
         if not self.use_easing(k):
             return k
         span = self.end_t - self.start_t
@@ -200,7 +200,7 @@ class EaseIn(EasingFunction):
         return k_new
 
 class EaseOut(EasingFunction):
-    def get_ease_start_t(self):
+    def get_ease_start_t(self) -> Number:
         #return self.curve.keyframes[-2]
         k_prev = -1
         for k in list(self.curve.keyframes)[::-1]:
@@ -212,7 +212,7 @@ class EaseOut(EasingFunction):
             k_prev = k
         else:
             return self.curve.keyframes[-2]
-    def get_ease_end_t(self):
+    def get_ease_end_t(self) -> Number:
         #return self.curve.keyframes[-1]
         k_prev = -1
         for k in list(self.curve.keyframes)[::-1]:
@@ -224,7 +224,7 @@ class EaseOut(EasingFunction):
             k_prev = k
         else:
             return self.curve.keyframes[-1]
-    def __call__(self,k):
+    def __call__(self,k:Number) -> Number:
         if not self.use_easing(k):
             return k
         span = self.end_t - self.start_t
@@ -311,7 +311,7 @@ class Curve:
             return self._duration
         return max(self.keyframes)+1
 
-    def __getitem__(self, k):
+    def __getitem__(self, k:Number) -> Number:
         """
         Under the hood, the values in our SortedDict should all be Keyframe objects,
         but indexing into this class should always return a number (Keyframe.value)
@@ -371,7 +371,7 @@ class Curve:
     def copy(self):
         return deepcopy(self)
 
-    def __add__(self, other):
+    def __add__(self, other) -> 'Curve':
         if isinstance(other, type(self)):
             return self.__add_curves__(other)
         outv = self.copy()
@@ -379,7 +379,7 @@ class Curve:
             outv[k]+=other
         return outv
 
-    def __add_curves__(self, other):
+    def __add_curves__(self, other) -> 'Curve':
         outv = self.copy()
         other = other.copy()
 
@@ -398,14 +398,14 @@ class Curve:
         
         return outv
 
-    def __mul__(self, other):
+    def __mul__(self, other) -> 'Curve':
         outv = self.copy()
         for i, k in enumerate(self.keyframes):
             kf = outv._data[k]
             kf.value = kf.value * other
             outv[k]=kf
         return outv
-    def __rmul__(self, other):
+    def __rmul__(self, other) -> 'Curve':
         return self*other
 
 
@@ -430,26 +430,26 @@ class ParameterGroup:
                 v = Curve(v)
             self.parameters[name] = v
 
-    def __getitem__(self, k):
+    def __getitem__(self, k) -> dict:
         wt = self.weight[k]
         return {name:param[k]*wt for name, param in self.parameters.items() }
 
     # this might cause performance issues down the line. deal with it later.
-    def copy(self):
+    def copy(self) -> 'ParameterGroup':
         return deepcopy(self)
 
-    def __add__(self, other):
+    def __add__(self, other) -> 'ParameterGroup':
         outv = self.copy()
         outv.weight = outv.weight + other
         return outv
 
-    def __mul__(self, other):
+    def __mul__(self, other) -> 'ParameterGroup':
         outv = self.copy()
         outv.weight = outv.weight * other
         return outv
 
-    def __radd__(self,other):
+    def __radd__(self,other) -> 'ParameterGroup':
         return self+other
 
-    def __rmul__(self, other):
+    def __rmul__(self, other) -> 'ParameterGroup':
         return self*other

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -109,32 +109,31 @@ class Keyframe:
         self.t=t
         self.value=value
         self.interpolation_method=interpolation_method
-    def __add__(self, other):
-        if isinstance(other, type(self)):
+    @classmethod
+    def _to_value(cls, other:Union['Keyframe', Number]):
+        """
+        Convenience function for working with objects that could either be a Keyframe or a Number
+        """
+        if isinstance(other, cls):
             other = other.value
-        return self.value + other
+        if not isinstance(other, Number):
+            raise TypeError
+        return other
+
+    def __add__(self, other):
+        return self.value + self._to_value(other)
     def __radd__(self,other):
         return self+other
     def __le__(self, other):
-        if isinstance(other, type(self)):
-            other = other.value
-        return self.value <= other
+        return self.value <= self._to_value(other)
     def __ge__(self, other):
-        if isinstance(other, type(self)):
-            other = other.value
-        return self.value >= other
+        return self.value >= self._to_value(other)
     def __lt__(self, other):
-        if isinstance(other, type(self)):
-            other = other.value
-        return self.value < other
+        return self.value < self._to_value(other)
     def __gt__(self, other):
-        if isinstance(other, type(self)):
-            other = other.value
-        return self.value > other
+        return self.value > self._to_value(other)
     def __mul__(self, other):
-        if isinstance(other, type(self)):
-            other = other.value
-        return self.value * other
+        return self.value * self._to_value(other)
     def __rmul__(self, other):
         return self*other
     def __eq__(self, other) -> bool:

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -1,13 +1,10 @@
-from keyframed import Curve, Prompt, ParameterGroup, register_interpolation_method, Keyframe
-from keyframed.curve import ensure_sorteddict_of_keyframes, bisect_left_value, INTERPOLATORS, PromptState
+from keyframed import Curve, ParameterGroup, register_interpolation_method, Keyframe
+from keyframed.curve import ensure_sorteddict_of_keyframes, bisect_left_value, INTERPOLATORS
 
 from numbers import Number
 
 def test_curve():
     c = Curve()
-
-def test_prompt():
-    p = Prompt("foo bar")
 
 def test_curve_looping():
     curve = Curve(((0, 0), (9, 9)), loop=True)
@@ -295,66 +292,6 @@ def test_pgroup_nontrivial():
 
 ###############################################
 
-import numpy as np
-import pytest
-
-def test_prompt_init():
-    prompt = Prompt("Hello World!", weight=1)
-    assert isinstance(prompt, Prompt)
-    assert prompt.attribute == "Hello World!"
-    assert isinstance(prompt.weight, Curve)
-    assert prompt.weight[0] == 1
-        
-def test_prompt_init_weight_curve():
-    weight = SortedDict({0: 1, 1: 2, 2: 3})
-    prompt = Prompt("Hello World!", weight=weight)
-    assert isinstance(prompt, Prompt)
-    assert prompt.attribute == "Hello World!"
-    assert isinstance(prompt.weight, Curve)
-        
-def test_prompt_init_encoder():
-    def encoder(prompt):
-        return np.array([prompt.count(c) for c in set(prompt)])
-    prompt = Prompt("Hello World!", weight=1, encoder=encoder)
-    assert isinstance(prompt, Prompt)
-    assert prompt.encoder == encoder
-
-def test_prompt_encoded():
-    def encoder(prompt):
-        return len(prompt)
-    prompt = Prompt("Hello World!", weight=1, encoder=encoder)
-    assert isinstance(prompt, Prompt)
-    assert prompt.encoder == encoder
-    assert prompt._attribute_encoded == len("Hello World!")
-    
-def test_prompt_getitem():
-    weight = SortedDict({0: 1, 1: 2, 2: 3})
-    prompt = Prompt("Hello World!", weight=weight)
-    prompt_state = prompt[1]
-    assert isinstance(prompt_state, PromptState)
-    assert prompt_state.weight == 2
-    assert prompt_state.attribute == "Hello World!"
-        
-def test_prompt_getitem_encoder():
-    def encoder(prompt):
-        return np.array([prompt.count(c) for c in set(prompt)])
-    weight = SortedDict({0: 1, 1: 2, 2: 3})
-    prompt = Prompt("Hello World!", weight=weight, encoder=encoder)
-    prompt_state = prompt[1]
-    #assert isinstance(prompt_state, PromptState)
-    #assert isinstance(prompt_state.attribute, np.ndarray)
-    assert isinstance(prompt_state, np.ndarray)
-
-def test_prompt_getitem_encoded():
-    def encoder(prompt):
-        return len(prompt)
-    weight = SortedDict({0: 1, 1: 2, 2: 3})
-    prompt = Prompt("Hello World!", weight=weight, encoder=encoder)
-    prompt_state = prompt[1]
-    assert isinstance(prompt_state, Number)
-    assert prompt_state == 2*len("Hello World!")
-
-################################
 
 def test_Curve_default_interpolation():
     curve = Curve(default_interpolation='previous')


### PR DESCRIPTION
let's keep our attention constrained to "curve" tooling in this library. Prompts are objects that have curves attached to them, and I think it makes sense to have them live in a different library that has this one as a dependency. Adds unnecessary complexity here.