### PR TITLE
moved `__len__` to `.duration` to accomodate floats

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ print(parameter_group[0])  # {"volume": 1.0, "pitch": 2.0, "rate": 2.0}
 ```
 
 ParameterGroups can also be used to visualize curves together. The `ParameterGroup.plot()` method
-will use the length of the longest curve in the group as the domain for the plot.
+will use the duration of the longest curve in the group as the domain for the plot.
 
 ```python
 from keyframed import Curve, SmoothCurve, ParameterGroup

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ Keyframed is a time series data type that allows users to store and retrieve dat
         
 setup(
     name='keyframed',
-    version='0.2.3',
+    version='0.2.4',
     author='David Marx',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -166,22 +166,22 @@ def test_Keyframe():
 def test_curve():
     # Test basic curve construction
     curve1 = Curve()
-    assert len(curve1) == 1
+    assert curve1.duration == 0
     assert list(curve1.keyframes) == [0]
     assert list(curve1.values) == [0]
     
     curve2 = Curve(duration=5)
-    assert len(curve2) == 5
+    assert curve2.duration == 5
     assert list(curve2.keyframes) == [0]
     assert list(curve2.values) == [0]
     
     curve3 = Curve(((0,0), (2,2)))
-    assert len(curve3) == 3
+    assert curve3.duration == 2
     assert list(curve3.keyframes) == [0, 2]
     assert list(curve3.values) == [0, 2]
     
     curve4 = Curve({0:0, 2:2})
-    assert len(curve4) == 3
+    assert curve4.duration == 2
     assert list(curve4.keyframes) == [0, 2]
     assert list(curve4.values) == [0, 2]
     


### PR DESCRIPTION
python's `len` function throws an error if an objects `__len__` method returns a value other than `int`. my use of `len` was arguably an abuse of notation anyway, migrated the `__len__` methods I was using for curve durations into a more explicit `duration` attribute. while I was mucking around, changed duration calculation to be just the max keyframe rather than 1+max(c.keyframes). where the 1+ was needed (loop modulo) I added it. somewhat concerned this change might cause regressions but at least at the moment all tests are green.