### PR TITLE
improvements to arithmetic logic

### DIFF
--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -7,7 +7,7 @@ import random, string
 from sortedcontainers import SortedDict
 from typing import List, Tuple, Optional, Union, Dict, Callable
 
-#from loguru import logger
+from loguru import logger
 
 def ensure_sorteddict_of_keyframes(curve: 'Curve',default_interpolation:Union[str,Callable]='previous') -> SortedDict:
     """
@@ -350,14 +350,19 @@ class CurveBase(ABC):
         return f"curve_{id_generator()}"
 
     def __sub__(self, other):
+        logger.debug("curvebase.sub")
         return self + (-1 * other)
     def __rsub__(self, other):
-        return (-1*self) + other
+        logger.debug("curvebase.rsub")
+        #return (-1*self) + other
+        return other + (self*(-1))
+        #return other - self
 
     def __radd__(self,other) -> 'CurveBase':
         return self+other
 
     def __rmul__(self, other) -> 'CurveBase':
+        logger.debug("curvebase.rmul")
         return self*other
 
 
@@ -534,14 +539,22 @@ class Curve(CurveBase):
         return Composition(parameters=params, label=new_label, reduction='add')
 
     def __mul__(self, other) -> CurveBase:
+        logger.debug('curve.mul')
+        logger.debug(other)
         if isinstance(other, CurveBase):
             return self.__mul_curves__(other)
-        outv = self.copy()
-        for i, k in enumerate(self.keyframes):
-            kf = outv._data[k]
-            kf.value = kf.value * other
-            outv[k]=kf
-        return outv
+        label_ = f"( {other} * {self.label} )"
+        logger.debug(label_)
+        other = Curve(other)
+        return Composition(parameters=(self, other), label=label_, reduction='multiply')
+        #return self.__mul_curves__(other)
+        # outv = self.copy()
+        # for i, k in enumerate(self.keyframes):
+        #     kf = outv._data[k]
+        #     kf.value = kf.value * other
+        #     outv[k]=kf
+        # logger.debug(outv)
+        # return outv
     
     def __mul_curves__(self, other) -> 'Composition':
         if isinstance(other, ParameterGroup):
@@ -655,6 +668,10 @@ class ParameterGroup(CurveBase):
     def values(self):
         return [self[k] for k in self.keyframes]
 
+    def random_label(self):
+        #return super().random_label()
+        return f"pgroup({','.join([c.label for c in self.parameters.values])})"
+
 import operator
 
 REDUCTIONS = {
@@ -703,6 +720,8 @@ class Composition(ParameterGroup):
         f = REDUCTIONS.get(self.reduction)
 
         vals = [curve[k] for curve in self.parameters.values()]
+        logger.debug(self.label)
+        logger.debug(vals)
         outv = reduce(f, vals)
         if self.reduction in ('avg', 'average', 'mean'):
             outv = outv * (1/ len(vals))

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from functools import reduce
 import math
 from numbers import Number
+import operator
 import random, string
 from sortedcontainers import SortedDict
 from typing import List, Tuple, Optional, Union, Dict, Callable
@@ -584,8 +585,6 @@ class DictValuesArithmeticFriendly(UserDict):
         return self.__arithmetic_helper(other, operator.sub)
     def __neg__(self, other):
         return self.__arithmetic_helper(other, operator.neg)
-    
-
 
 
 class ParameterGroup(CurveBase):
@@ -624,7 +623,6 @@ class ParameterGroup(CurveBase):
             v.label = name
             self.parameters[name] = v
         if label is None:
-            #label = super().random_label() 
             label = self.random_label()
         self.label = label
 
@@ -660,7 +658,6 @@ class ParameterGroup(CurveBase):
             curve = curve.copy()
             curve = curve * self.weight
             curve.plot(n=n, xs=xs, eps=eps, *args, **kargs)
-            
 
     @property
     def keyframes(self):
@@ -678,18 +675,18 @@ class ParameterGroup(CurveBase):
     def random_label(self):
         return f"pgroup({','.join([c.label for c in self.parameters.values()])})"
 
-import operator
+
 
 REDUCTIONS = {
-    'add': operator.add, #lambda x,y:x+y,
-    'sum': operator.add, # lambda x,y:x+y,
-    'multiply': operator.mul, # lambda x,y:x*y,
-    'product': operator.mul, # lambda x,y:x*y,
-    'prod': operator.mul, # lambda x,y:x*y, # what is wrong with me...
-    'subtract': operator.sub, # lambda x,y:x-y,
-    'sub': operator.sub, # lambda x,y:x-y,
-    'divide': operator.truediv, # lambda x,y:x/y,
-    'div': operator.truediv, # lambda x,y:x/y,
+    'add': operator.add,
+    'sum': operator.add,
+    'multiply': operator.mul,
+    'product': operator.mul,
+    'prod': operator.mul,
+    'subtract': operator.sub,
+    'sub': operator.sub,
+    'divide': operator.truediv,
+    'div': operator.truediv,
     'max':max,
     'min':min,
     ## require special treatment by caller
@@ -741,8 +738,6 @@ class Composition(ParameterGroup):
     def __radd__(self, other):
         return super().__radd__(other)
 
-
-
     def __add__(self, other) -> 'Composition':
         if not isinstance(other, CurveBase):
             other = Curve(other)
@@ -756,8 +751,6 @@ class Composition(ParameterGroup):
         else:
             d = {pg_copy.label:pg_copy, other.label:other}
             return Composition(parameters=d, weight=pg_copy.weight, reduction='sum')
-
-
 
     def __mul__(self, other) -> 'ParameterGroup':
         if not isinstance(other, CurveBase):

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections import UserDict
 from copy import deepcopy
 from functools import reduce
 import math
@@ -562,9 +563,6 @@ def SmoothCurve(*args, **kargs):
     return Curve(*args, default_interpolation='eased_lerp', **kargs)
 
 
-# i'd kind of like this to inherit from dict.
-from collections import UserDict
-
 class DictValuesArithmeticFriendly(UserDict):
     def __arithmetic_helper(self, other, operator):
         outv = deepcopy(self)
@@ -594,6 +592,7 @@ class DictValuesArithmeticFriendly(UserDict):
         return self.__arithmetic_helper(other, operator.neg)
 
 
+# i'd kind of like this to inherit from dict. Maybe It can inherit from DictValuesArithmeticFriendly?
 class ParameterGroup(CurveBase):
     """
     The ParameterGroup class wraps a collection of named parameters to facilitate manipulating them as a unit.
@@ -683,7 +682,6 @@ class ParameterGroup(CurveBase):
         return f"pgroup({','.join([c.label for c in self.parameters.values()])})"
 
 
-
 REDUCTIONS = {
     'add': operator.add,
     'sum': operator.add,
@@ -696,7 +694,7 @@ REDUCTIONS = {
     'div': operator.truediv,
     'max':max,
     'min':min,
-    ## require special treatment by caller
+    ## requires special treatment by caller
     'mean': operator.add,
     'average': operator.add,
     'avg': operator.add,

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -363,6 +363,9 @@ class CurveBase(ABC):
     def __rmul__(self, other) -> 'CurveBase':
         return self*other
 
+    def __neg__(self):
+        return self * (-1)
+
 
 def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
     # via https://stackoverflow.com/questions/2257441/random-string-generation-with-upper-case-letters-and-digits
@@ -551,7 +554,6 @@ class Curve(CurveBase):
         pg = ParameterGroup(params)
         new_label = '*'.join(params.keys())
         return Composition(parameters=pg, label=new_label, reduction='multiply')
-
 
 
 def SmoothCurve(*args, **kargs):

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -644,7 +644,9 @@ class ParameterGroup(CurveBase):
 
     def __getitem__(self, k) -> dict:
         wt = self.weight[k]
-        return {name:param[k]*wt for name, param in self.parameters.items() }
+        #return {name:param[k]*wt for name, param in self.parameters.items() }
+        d = {name:param[k]*wt for name, param in self.parameters.items() }
+        return DictValuesArithmeticFriendly(d)
 
     # this might cause performance issues down the line. deal with it later.
     def copy(self) -> 'ParameterGroup':

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -588,8 +588,8 @@ class DictValuesArithmeticFriendly(UserDict):
         return (self * (-1)) + other
     def __sub__(self, other):
         return self.__arithmetic_helper(other, operator.sub)
-    def __neg__(self, other):
-        return self.__arithmetic_helper(other, operator.neg)
+    #def __neg__(self, other):
+    #    return self.__arithmetic_helper(other, operator.neg)
 
 
 # i'd kind of like this to inherit from dict. Maybe It can inherit from DictValuesArithmeticFriendly?

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -566,14 +566,17 @@ def SmoothCurve(*args, **kargs):
 
 
 class DictValuesArithmeticFriendly(UserDict):
-    def __arithmetic_helper(self, other, operator):
+    def __arithmetic_helper(self, operator, other=None):
         outv = deepcopy(self)
         for k,v in self.items():
-            outv[k] = operator(v, other)
+            if other is not None:
+                outv[k] = operator(v, other)
+            else:
+                outv[k] = operator(v)
         return outv
     def __add__(self, other):
         #print("bar")
-        return self.__arithmetic_helper(other, operator.add)
+        return self.__arithmetic_helper(operator.add, other)
     #def __div__(self, other):
     #    print("foo") # not even being called? maybe somethign funny with UserDict? whatever.
     #    #return self.__arithmetic_helper(other, operator.div)
@@ -581,7 +584,9 @@ class DictValuesArithmeticFriendly(UserDict):
     #def __rdiv__(self, other)
 
     def __mul__(self, other):
-        return self.__arithmetic_helper(other, operator.mul)
+        return self.__arithmetic_helper(operator.mul, other)
+    def __neg__(self):
+        return self.__arithmetic_helper(operator.neg)
     def __radd__(self, other):
         return self + other
     def __rmul__(self, other):
@@ -589,9 +594,7 @@ class DictValuesArithmeticFriendly(UserDict):
     def __rsub__(self, other):
         return (self * (-1)) + other
     def __sub__(self, other):
-        return self.__arithmetic_helper(other, operator.sub)
-    #def __neg__(self, other):
-    #    return self.__arithmetic_helper(other, operator.neg)
+        return self.__arithmetic_helper(operator.sub, other)
 
 
 # i'd kind of like this to inherit from dict. Maybe It can inherit from DictValuesArithmeticFriendly?

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -624,8 +624,8 @@ class ParameterGroup(CurveBase):
             v.label = name
             self.parameters[name] = v
         if label is None:
-            label = super().random_label() 
-            #self.random_label()
+            #label = super().random_label() 
+            label = self.random_label()
         self.label = label
 
     def __getitem__(self, k) -> dict:

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -577,6 +577,32 @@ def SmoothCurve(*args, **kargs):
 
 
 # i'd kind of like this to inherit from dict.
+from collections import UserDict
+
+class DictValuesArithmeticFriendly(UserDict):
+    def __arithmetic_helper(self, other, operator):
+        outv = deepcopy(self)
+        for k,v in self.items():
+            outv[k] = operator(v, other)
+        return outv
+    def __add__(self, other):
+        return self.__arithmetic_helper(other, operator.add)
+    def __mul__(self, other):
+        return self.__arithmetic_helper(other, operator.mul)
+    def __radd__(self, other):
+        return self + other
+    def __rmul__(self, other):
+        return self * other
+    def __rsub__(self, other):
+        return (self * (-1)) + other
+    def __sub__(self, other):
+        return self.__arithmetic_helper(other, operator.sub)
+    def __neg__(self, other):
+        return self.__arithmetic_helper(other, operator.neg)
+    
+
+
+
 class ParameterGroup(CurveBase):
     """
     The ParameterGroup class wraps a collection of named parameters to facilitate manipulating them as a unit.

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -350,19 +350,15 @@ class CurveBase(ABC):
         return f"curve_{id_generator()}"
 
     def __sub__(self, other):
-        logger.debug("curvebase.sub")
         return self + (-1 * other)
+
     def __rsub__(self, other):
-        logger.debug("curvebase.rsub")
-        #return (-1*self) + other
-        return other + (self*(-1))
-        #return other - self
+        return (-1*self) + other
 
     def __radd__(self,other) -> 'CurveBase':
         return self+other
 
     def __rmul__(self, other) -> 'CurveBase':
-        logger.debug("curvebase.rmul")
         return self*other
 
 
@@ -539,22 +535,11 @@ class Curve(CurveBase):
         return Composition(parameters=params, label=new_label, reduction='add')
 
     def __mul__(self, other) -> CurveBase:
-        logger.debug('curve.mul')
-        logger.debug(other)
         if isinstance(other, CurveBase):
             return self.__mul_curves__(other)
         label_ = f"( {other} * {self.label} )"
-        logger.debug(label_)
         other = Curve(other)
         return Composition(parameters=(self, other), label=label_, reduction='multiply')
-        #return self.__mul_curves__(other)
-        # outv = self.copy()
-        # for i, k in enumerate(self.keyframes):
-        #     kf = outv._data[k]
-        #     kf.value = kf.value * other
-        #     outv[k]=kf
-        # logger.debug(outv)
-        # return outv
     
     def __mul_curves__(self, other) -> 'Composition':
         if isinstance(other, ParameterGroup):
@@ -639,12 +624,12 @@ class ParameterGroup(CurveBase):
             v.label = name
             self.parameters[name] = v
         if label is None:
-            label = super().random_label() #self.random_label()
+            label = super().random_label() 
+            #self.random_label()
         self.label = label
 
     def __getitem__(self, k) -> dict:
         wt = self.weight[k]
-        #return {name:param[k]*wt for name, param in self.parameters.items() }
         d = {name:param[k]*wt for name, param in self.parameters.items() }
         return DictValuesArithmeticFriendly(d)
 
@@ -663,12 +648,6 @@ class ParameterGroup(CurveBase):
         for k,v in outv.parameters.items():
             outv.parameters[k] = v * other
         return outv
-
-    # def __radd__(self,other) -> 'ParameterGroup':
-    #     return self+other
-
-    # def __rmul__(self, other) -> 'ParameterGroup':
-    #     return self*other
 
     @property
     def duration(self):
@@ -697,8 +676,7 @@ class ParameterGroup(CurveBase):
         return [self[k] for k in self.keyframes]
 
     def random_label(self):
-        #return super().random_label()
-        return f"pgroup({','.join([c.label for c in self.parameters.values])})"
+        return f"pgroup({','.join([c.label for c in self.parameters.values()])})"
 
 import operator
 
@@ -741,8 +719,8 @@ class Composition(ParameterGroup):
         reduction:str=None,
         label:str=None,
     ):
-        super().__init__(parameters=parameters, weight=weight, label=label)
         self.reduction = reduction
+        super().__init__(parameters=parameters, weight=weight, label=label)
 
     def __getitem__(self, k):
         f = REDUCTIONS.get(self.reduction)

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -572,7 +572,14 @@ class DictValuesArithmeticFriendly(UserDict):
             outv[k] = operator(v, other)
         return outv
     def __add__(self, other):
+        #print("bar")
         return self.__arithmetic_helper(other, operator.add)
+    #def __div__(self, other):
+    #    print("foo") # not even being called? maybe somethign funny with UserDict? whatever.
+    #    #return self.__arithmetic_helper(other, operator.div)
+    #    return self.__arithmetic_helper(1/other, operator.mul)
+    #def __rdiv__(self, other)
+
     def __mul__(self, other):
         return self.__arithmetic_helper(other, operator.mul)
     def __radd__(self, other):

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -172,21 +172,26 @@ def test_add_pgroup_to_curve():
         assert test1[i] == test2[i] == {c.label:c[i] + fancy[i] for c in curves}
     
     fancy_neg = -fancy
-    #fancy_neg = -1*fancy
-    #fancy_neg = (-1)*fancy
-    #fancy_neg = fancy*(-1)
     for i in range(1,10):
-        assert fancy[i] != fancy_neg[i] # OK, NOW WE'RE GETTING SOMEWHERE
+        assert fancy[i] != fancy_neg[i]
+        assert fancy[i] == (-1) * fancy_neg[i]
+    fancy_neg = -1*fancy
+    for i in range(1,10):
+        assert fancy[i] != fancy_neg[i]
+        assert fancy[i] == (-1) * fancy_neg[i]
+    fancy_neg = (-1)*fancy
+    for i in range(1,10):
+        assert fancy[i] != fancy_neg[i]
+        assert fancy[i] == (-1) * fancy_neg[i]
+    fancy_neg = fancy*(-1)
+    for i in range(1,10):
+        assert fancy[i] != fancy_neg[i]
         assert fancy[i] == (-1) * fancy_neg[i]
 
     test1 = fancy - pgroup
     test2 = pgroup - fancy
     for i in range(10):
         assert test1[i] == {c.label:fancy[i] - c[i] for c in curves}
-        print(test2[i])
-        print(fancy[i])
-        print({c.label:c[i] for c in curves})
-        print({c.label:c[i] - fancy[i] for c in curves})
         assert test2[i] == {c.label:c[i] - fancy[i] for c in curves}
     
     test1 = fancy * pgroup

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,8 +1,8 @@
 from keyframed import ParameterGroup, Curve, SmoothCurve, Composition
 import numpy as np
 import math
-from numbers import Number
 
+from loguru import logger
 
 EPS = 1e-9
 
@@ -105,8 +105,6 @@ def test_float_arithmetic_on_nested_composition():
     c3 = c1+c2
     c4 = c3 * c1
     ##
-    from loguru import logger
-    
     c5a = 5 + c3
     c5b = c3 + 5
     c6a = 5 + c4
@@ -120,9 +118,9 @@ def test_float_arithmetic_on_nested_composition():
     c8b = c4 * 5
     ##
     for i in range(10):
-        logger.debug(i)
+        #logger.debug(i)
         #logger.debug(f"{c5a} - {c5a.label} - this::{c5a.parameters['this']} - that::{c5a.parameters['that']} - {c5a.weight}")
-        logger.debug(f"{c7a} - {c7a.label} - {c7a.weight} - {c7a.parameters} - {[str(curve) for curve in c7a.parameters.values()]}")
+        #logger.debug(f"{c7a} - {c7a.label} - {c7a.weight} - {c7a.parameters} - {[str(curve) for curve in c7a.parameters.values()]}")
         # first line is same as test_composition_of_composition
         assert c4[i] == (c1[i] + c2[i]) * c1[i]
         assert c5a[i] == 5 + c3[i]
@@ -138,7 +136,8 @@ def test_float_arithmetic_on_nested_composition():
 def test_mean_reduction():
     c1 = Curve({10:10}, default_interpolation='linear')
     c2 = Curve({1:1})
-    #mu = Composition((c1, c2), ) # to do: support composing curves passed in as a tuple. ditto parametergroups
+    #mu = Composition(c1, c2)  # to do: support composing curves passed in as a tuple. ditto parametergroups
+    #mu = Composition(ParameterGroup(c1, c2)) # to do: support composing curves passed in as a tuple. ditto parametergroups
     mu = Composition({c.label:c for c in (c1, c2)}, reduction='mean')
     for i in range(10):
         assert mu[i] == (c1[i] + c2[i])/2

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -209,4 +209,7 @@ def test_fancy_dict():
     assert d-1 == {'a':-2,'b':-1,'c':0}
     assert -1+d == {'a':-2,'b':-1,'c':0}
     ##
+    assert 1-d == {'a':2, 'b':1, 'c':0}
+    assert -d + 1 == {'a':2, 'b':1, 'c':0}
+    ##
     #assert d/2 == {'a':-1/2,'b':0,'c':1/2}

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -163,7 +163,13 @@ def test_add_pgroup_to_curve():
     pgroup = ParameterGroup(curves)
 
     ampl = high
+    # Ok i think i've figured it out and I don't have a great solution for the problem.
+    # the issue here is that multiplying an integer into a curve multiplies the integer into the keyfram values, so 
+    # if the curve is primarily written by the 'interpolator', the multiplication
+    # gets ignored because the multiplication doesn't impact the interpolation function.
+    # i think the only solution here is to coerce the multiplicand into a trivial curve and return a composition
     fancy = Curve({0:0}, default_interpolation=lambda k,_: ampl + math.sin(2*k/(step1+step2)))
+    #fancy = Curve({0:0.0001}, default_interpolation=lambda k,_: ampl + math.sin(2*k/(step1+step2)))
     #fancy = Curve({100:100}, default_interpolation='linear')
 
     test1 = fancy + pgroup
@@ -172,7 +178,9 @@ def test_add_pgroup_to_curve():
         assert test1[i] == test2[i] == {c.label:c[i] + fancy[i] for c in curves}
     
     #fancy_neg = -fancy # need to add the unary negation operand
-    fancy_neg = -1*fancy
+    #fancy_neg = -1*fancy
+    #fancy_neg = (-1)*fancy
+    fancy_neg = fancy*(-1)
     for i in range(1,10):
         assert fancy[i] != fancy_neg[i] # OK, NOW WE'RE GETTING SOMEWHERE
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -165,25 +165,21 @@ def test_add_pgroup_to_curve():
     # gets ignored because the multiplication doesn't impact the interpolation function.
     # i think the only solution here is to coerce the multiplicand into a trivial curve and return a composition
     fancy = Curve({0:0}, default_interpolation=lambda k,_: ampl + math.sin(2*k/(step1+step2)))
-    #fancy = Curve({0:0.0001}, default_interpolation=lambda k,_: ampl + math.sin(2*k/(step1+step2)))
-    #fancy = Curve({100:100}, default_interpolation='linear')
 
     test1 = fancy + pgroup
     test2 = pgroup + fancy
     for i in range(10):
         assert test1[i] == test2[i] == {c.label:c[i] + fancy[i] for c in curves}
     
-    #fancy_neg = -fancy # need to add the unary negation operand
-    #fancy_neg = -1*fancy
+    #fancy_neg = -fancy # To do: add the unary negation operand
+    fancy_neg = -1*fancy
     #fancy_neg = (-1)*fancy
-    fancy_neg = fancy*(-1)
+    #fancy_neg = fancy*(-1)
     for i in range(1,10):
         assert fancy[i] != fancy_neg[i] # OK, NOW WE'RE GETTING SOMEWHERE
 
     test1 = fancy - pgroup
     test2 = pgroup - fancy
-    #test2 = pgroup + (-1* fancy)
-    #test2 = pgroup + (fancy*(-1))
     for i in range(10):
         assert test1[i] == {c.label:fancy[i] - c[i] for c in curves}
         print(test2[i])

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -215,3 +215,5 @@ def test_fancy_dict():
     ##
     assert d-1 == {'a':-2,'b':-1,'c':0}
     assert -1+d == {'a':-2,'b':-1,'c':0}
+    ##
+    #assert d/2 == {'a':-1/2,'b':0,'c':1/2}

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -64,14 +64,11 @@ def test_mul_curves():
 def test_mul_curves2():
     cos_curve = Curve({0:0}, default_interpolation=lambda k,curve: math.cos(k))
     sin_curve = Curve({0:0}, default_interpolation=lambda k,curve: math.sin(k))
+    mul_curve = cos_curve * sin_curve
 
     xs = np.linspace(0,4*np.pi, 100)
-    ys_cos = [cos_curve[x] for x in xs]
-    ys_sin = [sin_curve[x] for x in xs]
-
-    mul_curve = cos_curve * sin_curve
-    ys_mul = [mul_curve[x] for x in xs]
-    assert isinstance(ys_mul[0], Number)
+    for i, x in enumerate(xs):
+        assert mul_curve[x] == cos_curve[x] * sin_curve[x]
 
 def test_mul_loop_to_curve():
     pass

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -171,12 +171,13 @@ def test_add_pgroup_to_curve():
     for i in range(10):
         assert test1[i] == test2[i] == {c.label:c[i] + fancy[i] for c in curves}
     
-    #fancy_neg = -fancy # To do: add the unary negation operand
-    fancy_neg = -1*fancy
+    fancy_neg = -fancy
+    #fancy_neg = -1*fancy
     #fancy_neg = (-1)*fancy
     #fancy_neg = fancy*(-1)
     for i in range(1,10):
         assert fancy[i] != fancy_neg[i] # OK, NOW WE'RE GETTING SOMEWHERE
+        assert fancy[i] == (-1) * fancy_neg[i]
 
     test1 = fancy - pgroup
     test2 = pgroup - fancy

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -185,9 +185,9 @@ def test_add_pgroup_to_curve():
         assert fancy[i] != fancy_neg[i] # OK, NOW WE'RE GETTING SOMEWHERE
 
     test1 = fancy - pgroup
-    #test2 = pgroup - fancy
+    test2 = pgroup - fancy
     #test2 = pgroup + (-1* fancy)
-    test2 = pgroup + (fancy*(-1))
+    #test2 = pgroup + (fancy*(-1))
     for i in range(10):
         assert test1[i] == {c.label:fancy[i] - c[i] for c in curves}
         print(test2[i])
@@ -200,3 +200,18 @@ def test_add_pgroup_to_curve():
     test2 = pgroup * fancy
     for i in range(10):
         assert test1[i] == test2[i] == {c.label:c[i] * fancy[i] for c in curves}
+
+###############################################################
+
+from keyframed.curve import DictValuesArithmeticFriendly
+
+def test_fancy_dict():
+    d = DictValuesArithmeticFriendly({'a':-1, 'b':0, 'c':1})
+    assert d+1 == {'a':0,'b':1,'c':2}
+    assert 1+d == {'a':0,'b':1,'c':2}
+    ##
+    assert d*2 == {'a':-2,'b':0,'c':2}
+    assert 2*d == {'a':-2,'b':0,'c':2}
+    ##
+    assert d-1 == {'a':-2,'b':-1,'c':0}
+    assert -1+d == {'a':-2,'b':-1,'c':0}


### PR DESCRIPTION
previously, if a curve was defined implicitly by a callable interpolation method, arithmetic operations on the curve could result in unexpected behavior because we were naively performing arithmetic on the keyframe values directly wherever possible.

these changes resolve this by forcing all arithmetic operations on curves to return compositions, so the results of the arithmetic are evaluated just in time rather than trying to construct on object that captures the arithmetic result and querying that.

additionally, created a specialized dict to wrap return values of `ParameterGroup.__getitem__` to make them compatible with the reduction operations of compositions.