### PR TITLE
Simplified yaml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ Keyframed is a time series data type that allows users to store and retrieve dat
         
 setup(
     name='keyframed',
-    version='0.3.1',
+    version='0.3.2',
     author='David Marx',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -356,7 +356,7 @@ class Curve(CurveBase):
                     rec = tuple(rec.values())
                     recs.append(rec)
                 else:
-                    t = rec.pop(t)
+                    t = rec.pop('t')
                     d_curve[t] = rec
 
             if for_yaml:

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -509,6 +509,7 @@ class ParameterGroup(CurveBase):
             label=self.label,
         )
         else:
+            [params[k].pop('label') for k in list(params.keys())] # curve.label is redundant with pgroup.parameters.keys()
             outv = {'parameters':params}
             wt2 = deepcopy(weight)
             if 'label' in wt2:

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -347,8 +347,6 @@ class Curve(CurveBase):
             implied_interpolation = 'previous'
             for kf in self._data.values():
                 if ((kf.t == 0) and (kf.value == 0) and (kf.interpolation_method == implied_interpolation)):
-                    print(kf)
-                    print('continuing')
                     continue
                 rec = {'t':kf.t,'value':kf.value}
                 if kf.interpolation_method != implied_interpolation:

--- a/src/keyframed/curve.py
+++ b/src/keyframed/curve.py
@@ -409,7 +409,9 @@ class ParameterGroup(CurveBase):
             pg = parameters
             self.parameters = pg.parameters
             self._weight = pg.weight
-            self.label = pg.label # to do: I think this should probably be a random label gen
+            if label is None:
+                label = pg.label # to do: I think this should probably be a random label gen
+            self.label = label
             return
         self.parameters = {}
         for name, v in parameters.items():
@@ -509,7 +511,11 @@ class ParameterGroup(CurveBase):
             label=self.label,
         )
         else:
-            [params[k].pop('label') for k in list(params.keys())] # curve.label is redundant with pgroup.parameters.keys()
+            #[params[k].pop('label') for k in list(params.keys())] # curve.label is redundant with pgroup.parameters.keys()
+            for k in list(params.keys()):
+                if 'label' in params[k]:
+                    params[k].pop('label')
+
             outv = {'parameters':params}
             wt2 = deepcopy(weight)
             if 'label' in wt2:

--- a/src/keyframed/serialization.py
+++ b/src/keyframed/serialization.py
@@ -84,22 +84,31 @@ def from_dict(d:dict):
     if _is_curve(d):
         return Curve(**d)
     
-    if _is_pgroup(d):
+    if _is_pgroup(d) or _is_comp(d):
         #pass
-        d_ = dict(
-            label=d['label'],
-            weight=from_dict(d['weight'])
-        )
+        d_ = {}
+            #label=d['label'],
+        #    weight=from_dict(d['weight'])
+        #)
+        if d.get('label') is not None:
+            d_['label'] = d['label']
+        if d.get('weight') is not None:
+            d_['weight'] = from_dict(d['weight'])
+
         curves = {}
         for k,v in d['parameters'].items():
             curves[k] = from_dict(v)
         d_['parameters'] = curves
 
         logger.debug(d_)
-        return ParameterGroup(**d_)
+        if not _is_comp(d):
+            return ParameterGroup(**d_)
+        else:
+            d_['reduction'] = d['reduction']
+            return Composition(**d_)
 
-    if _is_comp(d):
-        pass
+    #if _is_comp(d):
+    #    pass
 
     raise NotImplementedError
 

--- a/src/keyframed/serialization.py
+++ b/src/keyframed/serialization.py
@@ -58,7 +58,8 @@ def _is_keyframe_tuple(d:tuple):
 #     return test1
 
 def _is_curve(d:dict):
-    return _test_type_by_keys(d, ATTRS_BY_TYPE['Curve'])
+    #return _test_type_by_keys(d, ATTRS_BY_TYPE['Curve'])
+    return 'curve' in d
     
 def _is_pgroup(d:dict):
     return _test_type_by_keys(d, ATTRS_BY_TYPE['ParameterGroup']) 

--- a/src/keyframed/serialization.py
+++ b/src/keyframed/serialization.py
@@ -62,14 +62,16 @@ def _is_curve(d:dict):
     return 'curve' in d
     
 def _is_pgroup(d:dict):
-    return _test_type_by_keys(d, ATTRS_BY_TYPE['ParameterGroup']) 
+    #return _test_type_by_keys(d, ATTRS_BY_TYPE['ParameterGroup']) 
     # can pgroups loop? if not, i should change that. 
     # Maybe I should rename ParameterGroup -> Track?
     # user friendly API: wrap a pgroup in a "TimeLine" class, user's can add curves using abstracted api. 
     # forces users to name things uniquely etc.
+    return ( ('parameters') in d and ('reduction' not in d) )
 
 def _is_comp(d:dict):
-    return _test_type_by_keys(d, ATTRS_BY_TYPE['Composition']) 
+    #return _test_type_by_keys(d, ATTRS_BY_TYPE['Composition']) 
+    return ( ('parameters') in d and ('reduction' in d) )
 
 def from_dict(d:dict):
     logger.debug(d)

--- a/src/keyframed/serialization.py
+++ b/src/keyframed/serialization.py
@@ -100,7 +100,12 @@ def from_dict(d:dict):
 
     raise NotImplementedError
 
-def to_yaml(obj:CurveBase, simplify=False):
+def to_yaml(obj:CurveBase, simplify=True):
     d = obj.to_dict(simplify=simplify, for_yaml=True)
     cfg = OmegaConf.create(d)
     return OmegaConf.to_yaml(cfg)
+
+def from_yaml(yaml_str:str):
+    cfg = OmegaConf.create(yaml_str)
+    d = OmegaConf.to_container(cfg)
+    return from_dict(d)

--- a/tests/test_curve_to_dict.py
+++ b/tests/test_curve_to_dict.py
@@ -49,7 +49,8 @@ def test_composition_to_dict():
     pg = ParameterGroup({'a':c0,'b':c1}, label='baz')
     comp = Composition(parameters=pg, reduction='sumfunc', label='boink')
     d = comp.to_dict()
-    assert d == {'parameters': {'a': {'curve': {0: {'t': 0, 'value': 0, 'interpolation_method': 'previous'}, 1: {'t': 1, 'value': 1, 'interpolation_method': 'previous'}, 5: {'t': 5, 'value': 5, 'interpolation_method': 'previous'}}, 'loop': False, 'duration': 5, 'label': 'a'}, 'b': {'curve': {0: {'t': 0, 'value': 0, 'interpolation_method': 'previous'}, 2: {'t': 2, 'value': 3, 'interpolation_method': 'previous'}, 7: {'t': 7, 'value': 6, 'interpolation_method': 'previous'}}, 'loop': False, 'duration': 7, 'label': 'b'}}, 'weight': {'curve': {0: {'t': 0, 'value': 1, 'interpolation_method': 'previous'}}, 'loop': False, 'duration': 0, 'label': 'baz_WEIGHT'}, 'label': 'baz', 'reduction': 'sumfunc'}
+    print(d)
+    assert d == {'parameters': {'a': {'curve': {0: {'t': 0, 'value': 0, 'interpolation_method': 'previous'}, 1: {'t': 1, 'value': 1, 'interpolation_method': 'previous'}, 5: {'t': 5, 'value': 5, 'interpolation_method': 'previous'}}, 'loop': False, 'duration': 5, 'label': 'a'}, 'b': {'curve': {0: {'t': 0, 'value': 0, 'interpolation_method': 'previous'}, 2: {'t': 2, 'value': 3, 'interpolation_method': 'previous'}, 7: {'t': 7, 'value': 6, 'interpolation_method': 'previous'}}, 'loop': False, 'duration': 7, 'label': 'b'}}, 'weight': {'curve': {0: {'t': 0, 'value': 1, 'interpolation_method': 'previous'}}, 'loop': False, 'duration': 0, 'label': 'boink_WEIGHT'}, 'label': 'boink', 'reduction': 'sumfunc'}
 
 
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -262,3 +262,47 @@ def test_curve_from_yaml_simplified3():
     assert c0.to_dict(simplify=True) == c1.to_dict(simplify=True)
     c1.label = c0.label
     assert c0 == c1
+
+def test_pgroup_to_yaml_simplified():
+    low, high = 0.0001, 0.3
+    step1 = 50
+    curves = ParameterGroup({
+        'foo':SmoothCurve({0:low, (step1-1):high, (2*step1-1):low}, loop=True),
+        'bar':SmoothCurve({0:high, (step1-1):low, (2*step1-1):high}, loop=True)
+    })
+    txt = to_yaml(curves, simplify=True)
+    print(txt)
+    raise
+    current_txt = """parameters:
+  foo:
+    curve:
+    - - 0
+      - 0.0001
+      - eased_lerp
+    - - 49
+      - 0.3
+    - - 99
+      - 0.0001
+    loop: true
+    label: foo
+  bar:
+    curve:
+    - - 0
+      - 0.3
+      - eased_lerp
+    - - 49
+      - 0.0001
+    - - 99
+      - 0.3
+    loop: true
+    label: bar
+weight:
+  curve:
+  - - 0
+    - 1
+  label: pgroup(foo,bar)_WEIGHT
+label: pgroup(foo,bar)"""
+    # to do: 
+    # - curve.label is redundant in parameter groups
+    # - parameter groups need a `_using_default_label` flag like with curve
+    # - `pgroup.weight == Curve(1)`` is redundant

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -306,16 +306,9 @@ def test_comp_pgroup_to_yaml_simplified():
         'bar':SmoothCurve({0:high, (step1-1):low, (2*step1-1):high}, loop=True)
     })
     #curves2 = curves*1
-    c1 = curves*1
-    c2 = 1*curves
-    for c in (c1, c2):
-        for curvename in list(c.parameters.keys()):
-            if curvename not in ('foo','bar'):
-                print(curvename)
-                assert curvename.startswith('curve_')
-                thiscurve = c.parameters.pop(curvename)
-                thiscurve.label = 'multiplicand'
-                c.parameters[thiscurve.label] = thiscurve
+    c_ = Curve(2, label="dummy")
+    c1 = curves*c_
+    c2 = c_*curves
 
     txt1 = to_yaml(c1, simplify=True)
     txt2 = to_yaml(c2, simplify=True)
@@ -333,10 +326,10 @@ def test_comp_pgroup_to_yaml_simplified():
         - - 99
           - 0.0001
         loop: true
-      curve_DYE43D:
+      dummy:
         curve:
         - - 0
-          - 1
+          - 2
     reduction: multiply
   bar:
     parameters:
@@ -350,8 +343,8 @@ def test_comp_pgroup_to_yaml_simplified():
         - - 99
           - 0.3
         loop: true
-      curve_HPKI9T:
+      dummy:
         curve:
         - - 0
-          - 1
+          - 2
     reduction: multiply"""

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -272,8 +272,7 @@ def test_pgroup_to_yaml_simplified():
     })
     txt = to_yaml(curves, simplify=True)
     print(txt)
-    raise
-    current_txt = """parameters:
+    assert txt.strip() == """parameters:
   foo:
     curve:
     - - 0
@@ -284,7 +283,6 @@ def test_pgroup_to_yaml_simplified():
     - - 99
       - 0.0001
     loop: true
-    label: foo
   bar:
     curve:
     - - 0
@@ -294,8 +292,7 @@ def test_pgroup_to_yaml_simplified():
       - 0.0001
     - - 99
       - 0.3
-    loop: true
-    label: bar"""
+    loop: true"""
     # to do: 
     # - curve.label is redundant in parameter groups
     # - parameter groups need a `_using_default_label` flag like with curve

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -207,6 +207,10 @@ label: pgroup(foo,bar)"""
 #############################################
 
 def test_curve_to_yaml_simplified():
+    c0 = Curve()
+    txt = to_yaml(c0, simplify=True)
+    assert txt.strip() == "curve: []"
+
     c1 = Curve({1:1}, label='foo', default_interpolation='linear')
     txt = to_yaml(c1, simplify=True)
     assert txt.strip() == """curve:
@@ -216,3 +220,19 @@ def test_curve_to_yaml_simplified():
 - - 1
   - 1
 label: foo"""
+
+    c2 = Curve({1:1})
+    txt = to_yaml(c2, simplify=True)
+    assert txt.strip() == """curve:
+- - 1
+  - 1"""
+
+    c3 = Curve(((1,1,'linear'),(2,2)))
+    txt = to_yaml(c3, simplify=True)
+    print(txt)
+    assert txt.strip() == """curve:
+- - 1
+  - 1
+  - linear
+- - 2
+  - 2"""

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -349,3 +349,22 @@ def test_comp_pgroup_to_yaml_simplified():
         - - 0
           - 2
     reduction: multiply"""
+
+def test_comp_pgroup_from_yaml_simplified():
+    low, high = 0.0001, 0.3
+    step1 = 50
+    curves = ParameterGroup({
+        'foo':SmoothCurve({0:low, (step1-1):high, (2*step1-1):low}, loop=True),
+        'bar':SmoothCurve({0:high, (step1-1):low, (2*step1-1):high}, loop=True)
+    })
+    #curves2 = curves*1
+    c_ = Curve(2, label="dummy")
+    c1 = curves*c_
+    txt1 = to_yaml(c1, simplify=True)
+    print(txt1)
+    ### everything above this copied from test_comp_pgroup_to_yaml_simplified
+    c2 = from_yaml(txt1)
+    #assert c1 == c2
+    #assert c1.to_dict(simplify=True) == c2._to_dict(simplify=True) # to do: fix this
+    txt2 = to_yaml(c2, simplify=True)
+    assert txt1 == txt2

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -255,3 +255,10 @@ def test_curve_from_yaml_simplified2():
     assert c0.to_dict(simplify=True) == c1.to_dict(simplify=True)
     c1.label = c0.label
     assert c0 == c1
+
+def test_curve_from_yaml_simplified3():
+    c0 = Curve({1:1}, default_interpolation='linear')
+    c1 = from_yaml(to_yaml(c0, simplify=True))
+    assert c0.to_dict(simplify=True) == c1.to_dict(simplify=True)
+    c1.label = c0.label
+    assert c0 == c1

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -241,3 +241,10 @@ def test_curve_from_yaml():
     c0 = Curve()
     c1 = from_yaml(to_yaml(c0, simplify=False))
     assert c0 == c1
+
+def test_curve_from_yaml_simplified():
+    c0 = Curve()
+    c1 = from_yaml(to_yaml(c0, simplify=True))
+    assert c0.to_dict(simplify=True) == c1.to_dict(simplify=True)
+    c1.label = c0.label
+    assert c0 == c1

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,4 +1,4 @@
-from keyframed.serialization import from_dict, to_yaml
+from keyframed.serialization import from_dict, to_yaml, from_yaml
 from keyframed import Keyframe, Curve, ParameterGroup, Composition
 
 
@@ -73,7 +73,7 @@ def test_compositional_pgroup_from_yamldict():
 
 def test_curve_to_yaml():
     c1 = Curve({1:1}, label='foo', default_interpolation='linear')
-    txt = to_yaml(c1)
+    txt = to_yaml(c1, simplify=False)
     print(txt)
     assert txt.strip() == """curve:
 - - 0
@@ -90,8 +90,8 @@ def test_curve_sum_to_yaml():
     c0 = Curve({1:1}, label='foo', default_interpolation='linear')
     c1 = c0 + 1
     c2 = 1 + c0
-    txt1 = to_yaml(c1)
-    txt2 = to_yaml(c2)
+    txt1 = to_yaml(c1, simplify=False)
+    txt2 = to_yaml(c2, simplify=False)
     assert txt1 == txt2
     assert txt1.strip() == """curve:
 - - 0
@@ -118,8 +118,8 @@ def test_curve_prod_to_yaml():
                 thiscurve.label = 'bar'
                 c.parameters[thiscurve.label] = thiscurve
         
-    txt1 = to_yaml(c1)
-    txt2 = to_yaml(c2)
+    txt1 = to_yaml(c1, simplify=False)
+    txt2 = to_yaml(c2, simplify=False)
     print(txt1)
     print(txt2)
     
@@ -162,7 +162,7 @@ def test_pgroup_to_yaml():
         'foo':SmoothCurve({0:low, (step1-1):high, (2*step1-1):low}, loop=True),
         'bar':SmoothCurve({0:high, (step1-1):low, (2*step1-1):high}, loop=True)
     })
-    txt = to_yaml(curves)
+    txt = to_yaml(curves, simplify=False)
     print(txt)
     assert txt.strip() == """parameters:
   foo:
@@ -236,3 +236,8 @@ label: foo"""
   - linear
 - - 2
   - 2"""
+
+def test_curve_from_yaml():
+    c0 = Curve()
+    c1 = from_yaml(to_yaml(c0, simplify=False))
+    assert c0 == c1

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -248,3 +248,10 @@ def test_curve_from_yaml_simplified():
     assert c0.to_dict(simplify=True) == c1.to_dict(simplify=True)
     c1.label = c0.label
     assert c0 == c1
+
+def test_curve_from_yaml_simplified2():
+    c0 = Curve({1:1})
+    c1 = from_yaml(to_yaml(c0, simplify=True))
+    assert c0.to_dict(simplify=True) == c1.to_dict(simplify=True)
+    c1.label = c0.label
+    assert c0 == c1

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -313,6 +313,7 @@ def test_comp_pgroup_to_yaml_simplified():
     txt1 = to_yaml(c1, simplify=True)
     txt2 = to_yaml(c2, simplify=True)
     print(txt1)
+    assert txt1 == txt2
     assert txt1.strip() == """parameters:
   foo:
     parameters:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,5 +1,6 @@
-from keyframed.serialization import from_dict
+from keyframed.serialization import from_dict, to_yaml
 from keyframed import Keyframe, Curve, ParameterGroup, Composition
+
 
 def test_kf_from_dict():
     kf = Keyframe(t=0, value=1, interpolation_method='foobar')
@@ -37,14 +38,6 @@ def test_pgroup_curves_from_dict():
 
 ############################################
 
-# this is a duplicate of a test in test_curve_to_dict
-# def test_curve_from_yamldict():
-#     c1 = Curve({1:1}, label='foo', default_interpolation='linear')
-#     d = c1.to_dict(simplify=False, for_yaml=True)
-#     assert d == {'curve': ((0, 0, 'linear'), (1, 1, 'linear')), 'loop': False, 'duration': 1, 'label': 'foo'}
-#     c2 = from_dict(d)
-#     assert c1 == c2
-
 
 def test_pgroup_from_yamldict():
     c1 = Curve(label='foo')
@@ -74,9 +67,9 @@ def test_compositional_pgroup_from_yamldict():
     curves3 = from_dict(d)
     assert curves2 == curves3
 
-############
 
-from keyframed.serialization import to_yaml
+##############################################################################
+
 
 def test_curve_to_yaml():
     c1 = Curve({1:1}, label='foo', default_interpolation='linear')
@@ -209,3 +202,17 @@ weight:
   duration: 0
   label: pgroup(foo,bar)_WEIGHT
 label: pgroup(foo,bar)"""
+
+
+#############################################
+
+def test_curve_to_yaml_simplified():
+    c1 = Curve({1:1}, label='foo', default_interpolation='linear')
+    txt = to_yaml(c1, simplify=True)
+    assert txt.strip() == """curve:
+- - 0
+  - 0
+  - linear
+- - 1
+  - 1
+label: foo"""

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -295,13 +295,7 @@ def test_pgroup_to_yaml_simplified():
     - - 99
       - 0.3
     loop: true
-    label: bar
-weight:
-  curve:
-  - - 0
-    - 1
-  label: pgroup(foo,bar)_WEIGHT
-label: pgroup(foo,bar)"""
+    label: bar"""
     # to do: 
     # - curve.label is redundant in parameter groups
     # - parameter groups need a `_using_default_label` flag like with curve


### PR DESCRIPTION
adds support for more human friendly serialization by removing redundant information in the generated yaml (and supporting implicitly defined values)